### PR TITLE
[8.0.1.3.0] measurement_common

### DIFF
--- a/measurement_common/__openerp__.py
+++ b/measurement_common/__openerp__.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     "name": "Common Measurement Feature",
-    "version": "8.0.1.2.0",
+    "version": "8.0.1.3.0",
     "website": "https://opensynergy-indonesia.com",
     "author": "OpenSynergy Indonesia",
     "license": "AGPL-3",
@@ -19,6 +19,8 @@
     "data": [
         "security/ir.model.access.csv",
         "menu.xml",
+        "wizards/start_measurement.xml",
+        "wizards/end_measurement.xml",
         "views/measurement_type_views.xml",
         "views/measurement_item_type_views.xml",
         "views/measurement_template_views.xml",

--- a/measurement_common/models/measurement_common.py
+++ b/measurement_common/models/measurement_common.py
@@ -103,22 +103,10 @@ class MeasurementCommon(models.AbstractModel):
     real_date_start = fields.Datetime(
         string="Real Date Start",
         readonly=True,
-        states={
-            "open": [
-                ("readonly", False),
-                ("required", True),
-            ],
-        },
     )
     real_date_end = fields.Datetime(
         string="Real Date End",
         readonly=True,
-        states={
-            "open": [
-                ("readonly", False),
-                ("required", True),
-            ],
-        },
     )
     user_id = fields.Many2one(
         string="Responsible",
@@ -272,7 +260,7 @@ class MeasurementCommon(models.AbstractModel):
             document.write(document._prepare_start_data())
 
     @api.multi
-    def action_done(self):
+    def action_done(self, date_end=False):
         for document in self:
             document.write(document._prepare_done_data())
 
@@ -284,6 +272,7 @@ class MeasurementCommon(models.AbstractModel):
     @api.multi
     def action_restart(self):
         for document in self:
+            document.item_ids.unlink()
             document.write(document._prepare_restart_data())
 
     @api.multi
@@ -306,21 +295,25 @@ class MeasurementCommon(models.AbstractModel):
         }
 
     @api.multi
-    def _prepare_start_data(self):
+    def _prepare_start_data(self, date_start=False):
         self.ensure_one()
+        real_date_start = date_start or fields.Datetime.now()
         return {
             "state": "open",
             "start_date": fields.Datetime.now(),
             "start_user_id": self.env.user.id,
+            "real_date_start": real_date_start,
         }
 
     @api.multi
-    def _prepare_done_data(self):
+    def _prepare_done_data(self, date_end=False):
         self.ensure_one()
+        real_date_end = date_end or fields.Datetime.now()
         return {
             "state": "done",
             "done_date": fields.Datetime.now(),
             "done_user_id": self.env.user.id,
+            "real_date_end": real_date_end,
         }
 
     @api.multi
@@ -330,6 +323,8 @@ class MeasurementCommon(models.AbstractModel):
             "state": "cancel",
             "cancel_date": fields.Datetime.now(),
             "cancel_user_id": self.env.user.id,
+            "real_date_start": False,
+            "real_date_end": False,
         }
 
     @api.multi

--- a/measurement_common/models/measurement_item_common.py
+++ b/measurement_common/models/measurement_item_common.py
@@ -21,10 +21,31 @@ class MeasurementItemCommon(models.AbstractModel):
                 result = obj_option.search(criteria).ids
             document.allowed_qualitative_option_ids = result
 
+    @api.multi
+    @api.depends(
+        "quantitative_value",
+        "qualitative_option_id",
+        "uom_id",
+        "question_type",
+    )
+    def _compute_answer_string(self):
+        for document in self:
+            answer = ""
+            if document.question_type == "qualitative":
+                if document.qualitative_option_id:
+                    answer = document.qualitative_option_id.name
+            else:
+                answer = "%s %s" % (
+                    document.quantitative_value, document.uom_id.name)
+            document.answer_string = answer
+
     measurement_id = fields.Many2one(
         string="# Measurement",
         comodel_name="measurement.common",
         required=True,
+    )
+    date_answer = fields.Datetime(
+        string="Date",
     )
     item_type_id = fields.Many2one(
         string="Item",
@@ -43,6 +64,11 @@ class MeasurementItemCommon(models.AbstractModel):
             ("quantitative", "Quantitative"),
         ],
         required=True,
+    )
+    answer_string = fields.Char(
+        string="Answer",
+        compute="_compute_answer_string",
+        store=False,
     )
     quantitative_value = fields.Float(
         string="Quantitative Value",

--- a/measurement_common/models/measurement_item_type.py
+++ b/measurement_common/models/measurement_item_type.py
@@ -13,6 +13,9 @@ class MeasurementItemType(models.Model):
         string="Measurement Item Type",
         required=True,
     )
+    code = fields.Char(
+        string="Code",
+    )
     active = fields.Boolean(
         string="Active",
         default=True,

--- a/measurement_common/views/measurement_common_views.xml
+++ b/measurement_common/views/measurement_common_views.xml
@@ -86,8 +86,8 @@
             <header>
                 <button name="action_confirm" type="object" string="Confirm" class="oe_highlight" attrs="{'invisible':['|',('state','!=','draft'),('confirm_ok','=',False)]}" confirm="Confirm measurement. Are you sure?"/>
                 <button name="action_approve" type="object" string="Approve" class="oe_highlight" attrs="{'invisible':['|',('state','!=','confirm'),('approve_ok','=',False)]}" confirm="Approve measurement. Are you sure?"/>
-                <button name="action_start" type="object" string="Start" class="oe_highlight" attrs="{'invisible':['|',('state','!=','approve'),('start_ok','=',False)]}" confirm="Start measurement. Are you sure?"/>
-                <button name="action_done" type="object" string="Finish" class="oe_highlight" attrs="{'invisible':['|',('state','!=','open'),('done_ok','=',False)]}" confirm="Finish measurement. Are you sure?"/>
+                <button name="%(measurement_start_measurement_action)d" type="action" string="Start" class="oe_highlight" attrs="{'invisible':['|',('state','!=','approve'),('start_ok','=',False)]}" confirm="Start measurement. Are you sure?"/>
+                <button name="%(measurement_end_measurement_action)d" type="action" string="Finish" class="oe_highlight" attrs="{'invisible':['|',('state','!=','open'),('done_ok','=',False)]}" confirm="Finish measurement. Are you sure?"/>
                 <button name="%(base_print_policy.base_print_document_action)d" string="Print" type="action" icon="gtk-print"/>
                 <button name="%(base_cancel_reason.base_cancel_reason_wizard_action)d" type="action" string="Cancel" attrs="{'invisible':['|',('state','=','cancel'),('cancel_ok','=',False)]}" confirm="Cancel measurement. Are you sure?"/>
                 <button name="action_restart" type="object" string="Restart" attrs="{'invisible':['|',('state','!=','cancel'),('restart_ok','=',False)]}" confirm="Restart measurement. Are you sure?"/>
@@ -126,15 +126,24 @@
                 <notebook colspan="4">
                     <page name="item" string="Measurement Items">
                         <field name="item_ids" nolabel="1">
-                            <tree editable="top" create="false" delete="false">
-                                <field name="sequence" widget="handle"/>
+                            <tree create="false" delete="false">
                                 <field name="item_type_id"/>
                                 <field name="question_type"/>
-                                <field name="quantitative_value" attrs="{'readonly':[('question_type','=','qualitative')]}"/>
-                                <field name="uom_id" attrs="{'readonly':[('question_type','=','qualitative')]}"/>
-                                <field name="allowed_qualitative_option_ids" widget="many2many_tags" invisible="1"/>
-                                <field name="qualitative_option_id" domain="[('id','in',allowed_qualitative_option_ids[0][2])]" attrs="{'readonly':[('question_type','=','quantitative')]}"/>
+                                <field name="answer_string"/>
                             </tree>
+                            <form>
+                                <group name="item1" colspan="4" col="2" string="Question">
+                                    <field name="item_type_id" readonly="1"/>
+                                    <field name="sequence" readonly="1"/>
+                                    <field name="question_type" readonly="1"/>
+                                </group>
+                                <group name="item2" colspan="4" col="2" string="Answer">
+                                    <field name="quantitative_value" attrs="{'readonly':[('question_type','=','qualitative')], 'invisible':[('question_type','=','qualitative')]}"/>
+                                    <field name="uom_id" attrs="{'readonly':[('question_type','=','qualitative')], 'invisible':[('question_type','=','qualitative')]}"/>
+                                    <field name="allowed_qualitative_option_ids" widget="many2many_tags" invisible="1"/>
+                                    <field name="qualitative_option_id" domain="[('id','in',allowed_qualitative_option_ids[0][2])]" attrs="{'readonly':[('question_type','=','quantitative')], 'invisible':[('question_type','=','quantitative')]}"/>
+                                </group>
+                            </form>
                         </field>
                     </page>
                     <page name="note" string="Notes">

--- a/measurement_common/views/measurement_item_type_views.xml
+++ b/measurement_common/views/measurement_item_type_views.xml
@@ -9,6 +9,7 @@
     <field name="model">measurement.item_type</field>
     <field name="arch" type="xml">
         <search>
+            <field name="code"/>
             <field name="name"/>
         </search>
     </field>
@@ -20,6 +21,7 @@
     <field name="arch" type="xml">
         <tree>
             <field name="name"/>
+            <field name="code"/>
             <field name="question_type"/>
         </tree>
     </field>
@@ -31,9 +33,10 @@
     <field name="arch" type="xml">
         <form>
             <header/>
-            <div class="oe_right oe_button_box" style="width: 300px;" name="buttons"/>            
+            <div class="oe_right oe_button_box" style="width: 300px;" name="buttons"/>
             <group name="group_1" colspan="4" col="2">
                 <field name="name"/>
+                <field name="code"/>
                 <field name="active"/>
                 <field name="question_type"/>
             </group>

--- a/measurement_common/wizards/__init__.py
+++ b/measurement_common/wizards/__init__.py
@@ -3,6 +3,6 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import (
-    models,
-    wizards,
+    start_measurement,
+    end_measurement,
 )

--- a/measurement_common/wizards/end_measurement.py
+++ b/measurement_common/wizards/end_measurement.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 OpenSynergy Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from openerp import models, fields, api
+
+
+class EndMeasurement(models.TransientModel):
+    _name = "measurement.end_measurement"
+    _description = "End Measurement"
+
+    @api.model
+    def _default_date_end(self):
+        return fields.Datetime.now()
+
+    date_end = fields.Datetime(
+        string="Date End",
+        required=True,
+        default=lambda self: self._default_date_end(),
+    )
+
+    @api.multi
+    def action_end(self):
+        self.ensure_one()
+        object_name = self._context.get("active_model", False)
+        obj_measurement = self.env[object_name]
+        object_ids = self._context.get("active_ids", [])
+        for measurement_object in obj_measurement.browse(object_ids):
+            measurement_object.write(
+                measurement_object._prepare_done_data(self.date_end))

--- a/measurement_common/wizards/end_measurement.xml
+++ b/measurement_common/wizards/end_measurement.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2019 OpenSynergy Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+
+<openerp>
+<data>
+<record id="measurement_end_measurement_view_form" model="ir.ui.view">
+    <field name="name">measurement.end_measurement form</field>
+    <field name="model">measurement.end_measurement</field>
+    <field name="arch" type="xml">
+        <form>
+            <group name="header" colspan="4" col="2">
+                <field name="date_end"/>
+            </group>
+            <footer>
+                <button name="action_end" string="Done" class="oe_highlight" type="object"/>
+                or
+                <button special="cancel" string="Cancel" class="oe_link"/>
+            </footer>
+        </form>
+    </field>
+</record>
+
+<record id="measurement_end_measurement_action" model="ir.actions.act_window">
+    <field name="name">Finish Measurement</field>
+    <field name="type">ir.actions.act_window</field>
+    <field name="res_model">measurement.end_measurement</field>
+    <field name="view_type">form</field>
+    <field name="view_mode">form</field>
+    <field name="target">new</field>
+</record>
+
+</data>
+</openerp>

--- a/measurement_common/wizards/start_measurement.py
+++ b/measurement_common/wizards/start_measurement.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 OpenSynergy Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from openerp import models, fields, api
+
+
+class StartMeasurement(models.TransientModel):
+    _name = "measurement.start_measurement"
+    _description = "Start Measurement"
+
+    @api.model
+    def _default_date_start(self):
+        return fields.Datetime.now()
+
+    date_start = fields.Datetime(
+        string="Date Start",
+        required=True,
+        default=lambda self: self._default_date_start(),
+    )
+
+    @api.multi
+    def action_start(self):
+        self.ensure_one()
+        object_name = self._context.get("active_model", False)
+        obj_measurement = self.env[object_name]
+        object_ids = self._context.get("active_ids", [])
+        for measurement_object in obj_measurement.browse(object_ids):
+            measurement_object.write(
+                measurement_object._prepare_start_data(self.date_start))

--- a/measurement_common/wizards/start_measurement.xml
+++ b/measurement_common/wizards/start_measurement.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2019 OpenSynergy Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+
+<openerp>
+<data>
+<record id="measurement_start_measurement_view_form" model="ir.ui.view">
+    <field name="name">measurement.start_measurement form</field>
+    <field name="model">measurement.start_measurement</field>
+    <field name="arch" type="xml">
+        <form>
+            <group name="header" colspan="4" col="2">
+                <field name="date_start"/>
+            </group>
+            <footer>
+                <button name="action_start" string="Start" class="oe_highlight" type="object"/>
+                or
+                <button special="cancel" string="Cancel" class="oe_link"/>
+            </footer>
+        </form>
+    </field>
+</record>
+
+<record id="measurement_start_measurement_action" model="ir.actions.act_window">
+    <field name="name">Start Measurement</field>
+    <field name="type">ir.actions.act_window</field>
+    <field name="res_model">measurement.start_measurement</field>
+    <field name="view_type">form</field>
+    <field name="view_mode">form</field>
+    <field name="target">new</field>
+</record>
+
+</data>
+</openerp>


### PR DESCRIPTION
[measurement_common] Add code field

This field will be used for export/import measurement result

[measurement_common] Change real start & end date input

* Start and finish using wizard
* Real start and finish date readonly

[measurement_common] unlink measurement item when restart

[measurement_common] measurement item's input change

* Add field answer_string to represent answer on tree
* user will input answer on form

[measurement_common] add date_answer